### PR TITLE
iframeはXSS攻撃に使われるので禁止にした

### DIFF
--- a/lib/profile_text_scrubber.rb
+++ b/lib/profile_text_scrubber.rb
@@ -15,11 +15,21 @@ class ProfileTextScrubber < Rails::Html::PermitScrubber
       html head body title meta div span h1 h2 h3 h4 h5 h6 address p br em strong del ins abbr acronym
       dfn blockquote q cite sup sub pre code var kbd samp bdo font basefont big small b i s strike u tt
       center hr a base link ul ol li dl dt dd dir menu img map area object applet param table caption
-      thead tfoot tbody colgroup col tr td th frameset frame noframes style
+      thead tfoot tbody colgroup col tr td th frameset noframes style
     )
   end
 
   def skip_node?(node)
     node.text?
+  end
+
+  def allowed_node?(node)
+    @tags.include?(node.name) || allowed_iframe?(node)
+  end
+
+  def allowed_iframe?(node)
+    return false unless node.name == 'iframe'
+    return false if node.attributes['src'].nil?
+    return node.attributes['src'].value.start_with?('https://www.youtube.com/')
   end
 end

--- a/lib/profile_text_scrubber.rb
+++ b/lib/profile_text_scrubber.rb
@@ -15,7 +15,7 @@ class ProfileTextScrubber < Rails::Html::PermitScrubber
       html head body title meta div span h1 h2 h3 h4 h5 h6 address p br em strong del ins abbr acronym
       dfn blockquote q cite sup sub pre code var kbd samp bdo font basefont big small b i s strike u tt
       center hr a base link ul ol li dl dt dd dir menu img map area object applet param table caption
-      thead tfoot tbody colgroup col tr td th frameset frame noframes iframe style
+      thead tfoot tbody colgroup col tr td th frameset frame noframes style
     )
   end
 


### PR DESCRIPTION
iframeを使うと無限アラートをはじめ、XSS攻撃に利用できるので、許可リストから除去しました

ただし、srcがyoutubeを指定されたiframeは埋め込み可としています