### PR TITLE
各種rubocopをinstallする

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,10 @@
 # where the inspected file is and continue its way up to the root directory.
 #
 # See https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
+require:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 2.6
@@ -70,3 +74,6 @@ Style/StringLiterals:
 Style/SymbolArray:
   Enabled: false
 
+# defaultの指定がない`null: false`のmigrationを許容する
+Rails/NotNullColumn:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,10 @@ group :development do
   gem 'aws-sdk-s3', require: false
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'rubocop'
+  gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,13 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-performance (1.4.1)
+      rubocop (>= 0.71.0)
+    rubocop-rails (2.2.1)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
+    rubocop-rspec (1.35.0)
+      rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     sorcery (0.14.0)
@@ -265,6 +272,9 @@ DEPENDENCIES
   rails-html-sanitizer
   rspec-rails
   rubocop
+  rubocop-performance
+  rubocop-rails
+  rubocop-rspec
   sorcery
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
## 目的
各種rubocopを追加し、コードの統一性を上げる

## やったこと
* rubocop-performance install, rubocop-rails install, rubocop-rspec installの設定を追加

## 注意事項
Rails/NotNullColumを有効のままにしておくと、以下の警告が合計3件発生する。
```
db/migrate/20190626135535_add_master_division_id_to_master_group.rb:3:62: C: Rails/NotNullColumn: Do not add a NOT NULL column without a default value.
    add_column :master_groups, :master_division_id, :bigint, null: false, after: :name
                                                             ^^^^^^^^^^^
```
すでに反映しているmigrateでの警告となるので、現状のままにしたい点と
テーブルがない場合のMySQLではエラーとならないため、Rails/NotNullColumをdisableにしている